### PR TITLE
Change to support costomsim as spice engine

### DIFF
--- a/compiler/characterizer/charutils.py
+++ b/compiler/characterizer/charutils.py
@@ -12,13 +12,19 @@ def relative_compare(value1,value2,error_tolerance=0.001):
 
 def parse_output(filename, key):
     """Parses a hspice output.lis file for a key value"""
-    full_filename="{0}{1}.lis".format(OPTS.openram_temp, filename)
+    if OPTS.spice_version == "xa" :
+        full_filename="{0}xa.meas".format(OPTS.openram_temp)
+    else :
+        full_filename="{0}{1}.lis".format(OPTS.openram_temp, filename)
+
     try:
         f = open(full_filename, "r")
     except IOError:
         debug.error("Unable to open spice output file: {0}".format(full_filename),1)
     contents = f.read()
-    val = re.search(r"{0}\s*=\s*(-?\d+.?\d*\S*)\s+.*".format(key), contents)
+    # val = re.search(r"{0}\s*=\s*(-?\d+.?\d*\S*)\s+.*".format(key), contents)
+    val = re.search(r"{0}\s*=\s*(-?\d+.?\d*[e]?[-+]?[0-9]*\S*)\s+.*".format(key), contents)
+    
     if val != None:
         debug.info(3, "Key = " + key + " Val = " + val.group(1))
         return val.group(1)

--- a/compiler/characterizer/stimuli.py
+++ b/compiler/characterizer/stimuli.py
@@ -277,7 +277,11 @@ def run_sim():
     """Run hspice in batch mode and output rawfile to parse."""
     temp_stim = "{0}stim.sp".format(OPTS.openram_temp)
     
-    if OPTS.spice_version == "hspice":
+    
+    if OPTS.spice_version == "xa":
+        cmd = "{0} {1} -o {2}xa -mt 20".format(OPTS.spice_exe,temp_stim,OPTS.openram_temp)
+        valid_retcode=0
+    elif OPTS.spice_version == "hspice":
         # TODO: Should make multithreading parameter a configuration option
         cmd = "{0} -mt 2 -i {1} -o {2}timing".format(OPTS.spice_exe,
                                                                      temp_stim,


### PR DESCRIPTION
This change is to support customsim as spice simulation engine.
The new usage format is: 
openram.py -n -o testsram -p ../designdir/pkg45_testram -v example_config_freepdk45.py -s xa -c
